### PR TITLE
Set mysql user to `root`

### DIFF
--- a/brewworks.rb
+++ b/brewworks.rb
@@ -89,6 +89,7 @@ class Brewworks < Formula
       pid-file="#{project_dir}/mysql/mysqld.pid"
 
       [client]
+      user=root
       port=#{PORTS[:mysql]}
       socket="/tmp/mysql_#{PORTS[:mysql]}.sock"
     EOS


### PR DESCRIPTION
- Set the default mysql connection user to `root`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated MySQL configuration to set the user as `root` for the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->