### PR TITLE
ポート指定を配列のみにして複数サービスの開始をサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ wget https://raw.githubusercontent.com/koriym/homebrew-brewworks/1.x/brewworks.r
       "composer",
       "node"
     ]
-    # The port number for services that do not start is set to zero.
     PORTS = {
-      php: 9000,
-      mysql: 3306,
-      redis: 6379,
-      memcached: 11211,
-      nginx: 8080,
-      httpd: 8081
+      php: [9000],
+      mysql: [3306, 3307],
+      redis: [6379],
+      memcached: [11211],
+      nginx: [8080],
+      httpd: [8081]
     }
+    # The port number for services that do not start is set to zero.
     PHP_EXTENSIONS = ["xdebug", "pcov", "redis", "memcached"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This command will start all the services defined in your configuration file.
 . brewworks env
 ````
 
-This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. In addition to that, an alias `mysql@3306`, the client for each mysql service port, is created. This is useful for quick connections with argument-free commands and is easy to customise as it loads a project-specific my.conf.
+This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. In addition to that, an alias `mysql@3306`, the client for each mysql service port, is created. This is useful for quick connections with argument-free commands and is easy to customize as it loads a project-specific my.conf.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This command will start all the services defined in your configuration file.
 . brewworks env
 ````
 
-This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. The `mysql` client contains project-specific `my.conf` settings so you don't have to specify a port number or user name for every connection. A `mysql` command with no arguments will connect to the project-specific database.
+This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. `mysql -P 3306` - You must specify the port in this way to connect. (username and hostname can be omitted)
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This command will start all the services defined in your configuration file.
 . brewworks env
 ````
 
-This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. `mysql -P 3306` - You must specify the port in this way to connect. (username and hostname can be omitted)
+This environment variable setting causes `php` and `mysql` to point to the specified version of the binary. In addition to that, an alias `mysql@3306`, the client for each mysql service port, is created. This is useful for quick connections with argument-free commands and is easy to customise as it loads a project-specific my.conf.
 
 ## Project Structure
 

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -206,14 +206,16 @@ class Brewworks < Formula
   def write_env_script(script_dir, config_dir)
     (script_dir/"env.sh").write <<~SCRIPT
       #!/bin/bash
-      export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin:
-      export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin: \
-      #{HOMEBREW_PREFIX}/opt/redis/bin: \
-      #{HOMEBREW_PREFIX}/opt/memcached/bin: \
-      #{HOMEBREW_PREFIX}/opt/nginx/bin: \
-      #{HOMEBREW_PREFIX}/opt/httpd/bin:  \
+      export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin::$PATH"
+      export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:\
+      #{HOMEBREW_PREFIX}/opt/redis/bin:\
+      #{HOMEBREW_PREFIX}/opt/memcached/bin:\
+      #{HOMEBREW_PREFIX}/opt/nginx/bin:\
+      #{HOMEBREW_PREFIX}/opt/httpd/bin:\
       #{HOMEBREW_PREFIX}/opt/node/bin:$PATH"
       export PHP_INI_SCAN_DIR="#{config_dir}"
+      alias mysql="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql"
+      #{PORTS[:mysql].map { |port| "alias mysql@#{port}=\"#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql --defaults-file=#{config_dir}/my_#{port}.cnf -h 127.0.0.1"}.join("\n")}
     SCRIPT
 
     chmod "+x", script_dir/"env.sh"

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -207,12 +207,11 @@ class Brewworks < Formula
     (script_dir/"env.sh").write <<~SCRIPT
       #!/bin/bash
       export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin:
-      export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:
-      #{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:
-      #{HOMEBREW_PREFIX}/opt/redis/bin:
-      #{HOMEBREW_PREFIX}/opt/memcached/bin:
-      #{HOMEBREW_PREFIX}/opt/nginx/bin:
-      #{HOMEBREW_PREFIX}/opt/httpd/bin:
+      export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin: \
+      #{HOMEBREW_PREFIX}/opt/redis/bin: \
+      #{HOMEBREW_PREFIX}/opt/memcached/bin: \
+      #{HOMEBREW_PREFIX}/opt/nginx/bin: \
+      #{HOMEBREW_PREFIX}/opt/httpd/bin:  \
       #{HOMEBREW_PREFIX}/opt/node/bin:$PATH"
       export PHP_INI_SCAN_DIR="#{config_dir}"
     SCRIPT

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -111,6 +111,7 @@ class Brewworks < Formula
         user=root
         port=#{port}
         socket=#{tmp_dir}/mysql_#{port}.sock
+        prompt=mysql@#{port}:\\d>\\_
       CONF
     end
 

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -211,7 +211,7 @@ class Brewworks < Formula
       #{HOMEBREW_PREFIX}/opt/httpd/bin:
       #{HOMEBREW_PREFIX}/opt/node/bin:$PATH"
       export PHP_INI_SCAN_DIR="#{config_dir}"
-      alias mysql="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql --defaults-file=#{config_dir}/my.cnf"
+      alias mysql="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql"
     SCRIPT
 
     chmod "+x", script_dir/"env.sh"

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -4,6 +4,7 @@ class Brewworks < Formula
   url "file:///dev/null"
   version "1.0.0"
 
+  # -- Begin Configuration Section --
   PROJECT_NAME = "brewworks"
   PHP_VERSION = "8.3"
   MYSQL_VERSION = "8.0"
@@ -26,8 +27,10 @@ class Brewworks < Formula
     httpd: [8082]
   }
   PHP_EXTENSIONS = ["xdebug", "pcov", "redis", "memcached"]
+  # -- End Configuration Section --
 
   DEPENDENCIES.each { |dep| depends_on dep }
+
 
   def install
     project_dir = Pathname.new(prefix)/PROJECT_NAME

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -31,7 +31,6 @@ class Brewworks < Formula
 
   DEPENDENCIES.each { |dep| depends_on dep }
 
-
   def install
     project_dir = Pathname.new(prefix)/PROJECT_NAME
     script_dir = Pathname.new(prefix)/"script"
@@ -207,7 +206,7 @@ class Brewworks < Formula
   def write_env_script(script_dir, config_dir)
     (script_dir/"env.sh").write <<~SCRIPT
       #!/bin/bash
-      export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin::$PATH"
+      export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin:$PATH"
       export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:\
       #{HOMEBREW_PREFIX}/opt/redis/bin:\
       #{HOMEBREW_PREFIX}/opt/memcached/bin:\
@@ -216,7 +215,7 @@ class Brewworks < Formula
       #{HOMEBREW_PREFIX}/opt/node/bin:$PATH"
       export PHP_INI_SCAN_DIR="#{config_dir}"
       alias mysql="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql"
-      #{PORTS[:mysql].map { |port| "alias mysql@#{port}=\"#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql --defaults-file=#{config_dir}/my_#{port}.cnf -h 127.0.0.1"}.join("\n")}
+      #{PORTS[:mysql].map { |port| "alias mysql@#{port}=\"#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql --defaults-file=#{config_dir}/my_#{port}.cnf -h 127.0.0.1\"" }.join("\n")}
     SCRIPT
 
     chmod "+x", script_dir/"env.sh"

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -204,6 +204,7 @@ class Brewworks < Formula
     (script_dir/"env.sh").write <<~SCRIPT
       #!/bin/bash
       export PATH="#{HOMEBREW_PREFIX}/opt/php@#{PHP_VERSION}/bin:
+      export PATH="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:
       #{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin:
       #{HOMEBREW_PREFIX}/opt/redis/bin:
       #{HOMEBREW_PREFIX}/opt/memcached/bin:
@@ -211,7 +212,6 @@ class Brewworks < Formula
       #{HOMEBREW_PREFIX}/opt/httpd/bin:
       #{HOMEBREW_PREFIX}/opt/node/bin:$PATH"
       export PHP_INI_SCAN_DIR="#{config_dir}"
-      alias mysql="#{HOMEBREW_PREFIX}/opt/mysql@#{MYSQL_VERSION}/bin/mysql"
     SCRIPT
 
     chmod "+x", script_dir/"env.sh"


### PR DESCRIPTION
Closes #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated README to reflect new port configurations and PHP extensions.

- **Refactor**
  - Enhanced configuration handling to support multiple port values for services like MySQL, Redis, Memcached, Nginx, and Apache.

- **New Features**
  - Improved service management scripts to support starting and stopping services with multiple configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->