### PR TITLE
httpd.confを整理

### DIFF
--- a/brewworks.rb
+++ b/brewworks.rb
@@ -173,8 +173,6 @@ class Brewworks < Formula
         LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
         LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
         LoadModule authz_host_module lib/httpd/modules/mod_authz_host.so
-        LoadModule authz_user_module lib/httpd/modules/mod_authz_user.so
-        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
         LoadModule dir_module lib/httpd/modules/mod_dir.so
         
         ServerName localhost

--- a/brewworks.rb
+++ b/brewworks.rb
@@ -178,8 +178,6 @@ class Brewworks < Formula
         LoadModule dir_module lib/httpd/modules/mod_dir.so
         
         ServerName localhost
-        User www
-        Group www
         
         <IfModule dir_module>
             DirectoryIndex index.php index.html


### PR DESCRIPTION
## UserとGroupを削除

確認

```
% ps -eo pid,user,group,comm | grep httpd

16253 akihito             20 httpd
16263 akihito             20 httpd
16265 akihito             20 httpd
```
```

% cat /etc/group | grep ":20:"

staff:*:20:root
```

`User`は指定しないと実行ユーザーで`Goup`は`staff`になることを確認

## 最小構成にするために実は不要だったモジュールも削除

```
LoadModule authz_user_module lib/httpd/modules/mod_authz_user.so
LoadModule unixd_module lib/httpd/modules/mod_unixd.so
```

## 修正後のhttpd.conf

```apache
ServerName localhost
Listen 8080
DocumentRoot "/opt/homebrew/Cellar/brewworks/1.0.0/brewworks/public"
ErrorLog /opt/homebrew/Cellar/brewworks/1.0.0/brewworks/logs/httpd_8080_error.log

# Load necessary modules
LoadModule php_module /opt/homebrew/opt/php@8.3/lib/httpd/modules/libphp.so
LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
LoadModule authz_host_module lib/httpd/modules/mod_authz_host.so
LoadModule dir_module lib/httpd/modules/mod_dir.so
LoadModule rewrite_module lib/httpd/modules/mod_rewrite.so

# Directory settings
<Directory "/opt/homebrew/Cellar/brewworks/1.0.0/brewworks/public">
  Options Indexes FollowSymLinks
  AllowOverride All
  Require all granted
</Directory>

# File handling for PHP
<FilesMatch .php$>
  SetHandler application/x-httpd-php
</FilesMatch>

# Directory index settings
<IfModule dir_module>
    DirectoryIndex index.php index.html
</IfModule>

# Rewrite settings (commented out by default)
<IfModule rewrite_module>
    RewriteEngine On
    # Redirect all requests to index.php
    # RewriteCond %{REQUEST_FILENAME} !-f
    # RewriteCond %{REQUEST_FILENAME} !-d
    # RewriteRule ^ index.php [L]
</IfModule>
```

### 順序

- 基本設定
- モジュールの読み込み
- ディレクトリ設定
- ファイルハンドリング
- ディレクトリインデックス設定
- リライト設定

### AI評価

#### シ-ンプルで明確な構成

必要なモジュールのみを読み込み、設定がシンプルで明確です。

#### 初期設定として適切

リライトルールはデフォルトで無効にし、コメントアウトすることで初心者でも迷わない設定になっています。

#### 利便性を考慮

ディレクトリリスティング（Indexes）は有効にしており、開発中の利便性を考慮しています。

#### 拡張性

必要に応じてリライトルールを簡単に有効にできるように設定されています。

ローカル開発環境での使用を念頭に置いて、シンプルかつ実用的な構成となっています。初心者にも分かりやすく、必要に応じて設定を拡張できる柔軟性があります。

